### PR TITLE
Fix error when combine objects with different filter combinations

### DIFF
--- a/src/photozpy/calibration/combine.py
+++ b/src/photozpy/calibration/combine.py
@@ -164,14 +164,14 @@ class Combine():
         # first select image types (Flat or Light)
         collection_to_combine = CollectionManager.filter_collection(self._image_collection, **{"IMTYPE": [image_type]})
 
-        # flat or light IMTYPE has filters, get the filters used in the collection
-        filters = CollectionManager.get_header_values(collection_to_combine, "FILTER", unique = True)
-
         # Get the object names (Flat or various target names)
         object_names = HeaderManipulation.get_header_values(collection_to_combine, header = "object")  # It seems only the lower cases work
         object_names = [*set(object_names)]  # remove duplicate elements
+        print(f"The objects to be combined are {object_names}")
     
         for object_name in object_names:
+            collection_object = CollectionManager.filter_collection(self._image_collection, **{"object": [object_name]})
+            filters = CollectionManager.get_header_values(collection_object, "FILTER", unique = True)
             for filter in filters:
                 # get the image collection with specific filter and object name
                 collection_temp = CollectionManager.filter_collection(collection_to_combine, **{"OBJECT": [object_name], "FILTER": [filter]})


### PR DESCRIPTION
# Bug description
Sometimes, different targets will have different filters:
- target1: B
- target2: V

If we use `filters = CollectionManager.get_header_values(collection_to_combine, "FILTER", unique = True)` to get the filters first, we will loop both B and V filters for the two targets in :
```
for filter in filters:
    # get the image collection with specific filter and object name
    collection_temp = CollectionManager.filter_collection(collection_to_combine, **{"OBJECT": [object_name], "FILTER": [filter]})
```
, which will return a null `ImageFileCollection` (**no image found for target1 with V filter or target2 with B filter**. A null `ImageFileCollection` will return all the fits files in the directory when running 
`image_list_to_combine = list(collection_temp.files_filtered(include_path = True))`.

# How to fix
The core of the fix is to adjust the order of getting the filters:
1. First, loop over the object names
2. Second, get all the available filters of an object
3. Third, loop over object + available filters to make sure we include the object in its own available filters while rejecting the filters we didn't use for the object.