### PR TITLE
Fix multi-annulus background warning + pre-push hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    #branches: [develop]
   pull_request:
   workflow_dispatch:
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages: [pre-commit]  # 影响的是没有内置 stages、且你自己�
                               # 对于有内置stages，这个默认stage不会起效，需要在下面的hook
                               # 中显式定义，比如trailing-whitespace
 default_language_version:
-  python: python3.9
+  python: python3.11
 
 exclude: |
   (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-      istages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
+      #stages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
       - id: end-of-file-fixer           # 确保文件末尾只有 1 个换行
         #stages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
       - id: check-merge-conflict        # prevent committing conflict markers

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # .pre-commit-config.yaml (example with exclude)
-default_stages: [pre-commit]  # 影响的是没有内置 stages、且你自己没写 stages 的那些 hook
+default_install_hook_types: [pre-push]
+default_stages: [pre-push]  # 影响的是没有内置 stages、且你自己没写 stages 的那些 hook
                               # 对于有内置stages，这个默认stage不会起效，需要在下面的hook
                               # 中显式定义，比如trailing-whitespace
 default_language_version:
@@ -64,9 +65,9 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        stages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
+      istages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
       - id: end-of-file-fixer           # 确保文件末尾只有 1 个换行
-        stages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
+        #stages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
       - id: check-merge-conflict        # prevent committing conflict markers
       - id: check-yaml                  # validate .yml/.yaml
       - id: check-json                  # validate JSON files
@@ -76,7 +77,7 @@ repos:
         args: ["--fix=lf"]              # 统一 LF（推荐 macOS/Linux）
       - id: check-added-large-files     # 给「大文件」阈值一个你能接受的上限（默认 5MB）
         args: ["--maxkb=30000"]         # 5MB；或换成你项目想要的大小
-        stages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
+        #stages: [pre-commit]            # 覆盖默认stage，确保只在commit时运行
 
   # (Optional) basic spelling to catch obvious typos in docs/README
   - repo: https://github.com/codespell-project/codespell
@@ -104,5 +105,5 @@ repos:
         name: "pytest -m smoke (pre-push)"
         entry: bash -c 'pytest -q -m smoke -x --disable-warnings'
         language: system
-        stages: [pre-push]                  # run on git push, not on every commit, hook 没写 stages，实际上默认就是 [pre-commit]
+        #stages: [pre-push]                  # run on git push, not on every commit, hook 没写 stages，实际上默认就是 [pre-commit]
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ From the repository root (same folder as `pyproject.toml`):
 
 ```bash
 python -m pip install -e . --no-deps
-pre-commit install --hook-type pre-push -f
+pre-commit install -f
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ If you edit `environment.yml` later, update the environment with:
 conda env update -f environment.yml --prune
 ```
 
-### 4) Install `photozpy` in editable mode
+### 4) Install `photozpy` in editable mode and install pre-push hooks
 
 From the repository root (same folder as `pyproject.toml`):
 
 ```bash
 python -m pip install -e . --no-deps
+pre-commit install --hook-type pre-push -f
+
 ```
 
 ## Quick start

--- a/src/photozpy/photometry/photometry.py
+++ b/src/photozpy/photometry/photometry.py
@@ -24,7 +24,6 @@ import astropy.units as u
 from regions import CircleSkyRegion, Regions, CircleAnnulusSkyRegion
 from astropy.table import QTable
 import logging
-import warnings
 logger = logging.getLogger(__name__)
 
 

--- a/src/photozpy/photometry/photometry.py
+++ b/src/photozpy/photometry/photometry.py
@@ -141,14 +141,33 @@ class Photometry():
         median_bkg = bkg_stats.median
         sigma_ann = bkg_stats.std
 
-        if np.any(np.abs(mean_bkg - median_bkg) > tolerance * sigma_ann):
-            warnings.warn(
-                f"Background mean ({mean_bkg:.3f}) and median ({median_bkg:.3f}) differ "
-                f"by {abs(mean_bkg - median_bkg):.3f}, exceeding tolerance "
-                f"{tolerance:.2f} × sigma_ann ({sigma_ann:.3f}). "
-                "Possible residual contamination in annulus!",
-                UserWarning
+        diff = np.abs(mean_bkg - median_bkg)
+        bad = diff > tolerance * sigma_ann
+
+        if np.any(bad):
+            # get idx of the bkg annlus when differnece larger than tolerance
+            bad_idx = np.where(bad)[0] if bad.ndim > 0 else np.array([0], dtype=int)
+
+            lines = []
+            lines.append(
+                f"Background mean and median differ beyond tolerance for {bad_idx.size} annuli/annulus. "
+                f"indices={bad_idx.tolist()}"
             )
+
+            # write the warning text
+            for i in bad_idx:
+                i = int(i)
+                lines.append(
+                    "  "
+                    f"annulus index={i}  "
+                    f"mean={float(mean_bkg[i]):.4f}  "
+                    f"median={float(median_bkg[i]):.4f}  "
+                    f"diff={float(diff[i]):.4f}  "
+                    f"sigma={float(sigma_ann[i]):.4f}  "
+                    f"tol*sigma={float(tolerance * sigma_ann[i]):.4f}"
+                )
+    
+            logger.warning("\n".join(lines))
 
         return mean_bkg * (u.adu / u.pix), bkg_stats
 

--- a/src/photozpy/photometry/photometry.py
+++ b/src/photozpy/photometry/photometry.py
@@ -144,7 +144,7 @@ class Photometry():
         bad = diff > tolerance * sigma_ann
 
         if np.any(bad):
-            # get idx of the bkg annlus when differnece larger than tolerance
+            # get idx of the bkg annlus when difference larger than tolerance
             bad_idx = np.where(bad)[0] if bad.ndim > 0 else np.array([0], dtype=int)
 
             lines = []
@@ -165,7 +165,7 @@ class Photometry():
                     f"sigma={float(sigma_ann[i]):.4f}  "
                     f"tol*sigma={float(tolerance * sigma_ann[i]):.4f}"
                 )
-    
+
             logger.warning("\n".join(lines))
 
         return mean_bkg * (u.adu / u.pix), bkg_stats


### PR DESCRIPTION
### Context
`Photometry.estimate_mean_background()` uses `photutils.aperture.ApertureStats` to estimate background statistics in sky annuli. When multiple annuli are provided, `ApertureStats.mean/median/std` return arrays (one value per annulus/aperture).

The previous warning path formatted `mean_bkg/median_bkg/sigma_ann` using float format specifiers (e.g., `:.3f`). This raised `TypeError: unsupported format string passed to numpy.ndarray.__format__` when those values were numpy arrays.

In addition, we want consistent local quality gates when pushing (pre-push), but Git hooks are local to each clone, and must be installed per-repo.

### What this PR changes

#### 1) Multi-annulus background diagnostics
- Replaces scalar f-string formatting on `mean_bkg`, `median_bkg`, and `sigma_ann` with array-safe logic.
- Computes `diff = |mean - median|` and flags `bad` annuli where `diff > tolerance * sigma_ann`.
- Emits a single `logger.warning(...)` message that includes:
  - the list of failing annulus indices
  - per-annulus details (mean, median, diff, sigma, tolerance*sigma) for each flagged index
- Keeps existing background computation behavior unchanged (only fixes diagnostics/observability).

#### 2) Pre-push checks via `pre-commit` (local)
- Configure `pre-commit` to run checks at `pre-push` stage (smoke test plus lightweight hygiene/lint/format hooks as configured).
- Update `default_language_version` to Python 3.11 to match the dev environment.
- Add README instructions to install the `pre-push` hook after a fresh clone (since `.git/hooks` is not versioned).

### Why
- Prevents a runtime crash when multiple bkg annuli mean and median differ beyond tolerance.
- Preserves useful diagnostics for identifying contaminated/background-biased annuli, without interrupting pipeline execution.
- Ensures push-time checks are reproducible across machines by documenting and standardizing hook installation.

### Notes
- Logging is used instead of `warnings.warn` to integrate with pipeline log handling and batch processing.
- `pre-commit` hook environments may show "Installing environment for ..." on first run; subsequent runs reuse cached environments.

### Testing
- Verified with multi-standard-star runs (many annuli) that previously triggered the formatting TypeError.
- Confirmed no behavior change when no annuli exceed tolerance (no warning emitted).