### PR TITLE
Fix scalar background warning indexing in `estimate_mean_background`

### DIFF
--- a/src/photozpy/photometry/photometry.py
+++ b/src/photozpy/photometry/photometry.py
@@ -141,9 +141,9 @@ class Photometry():
         sigma_ann = bkg_stats.std
 
         # Ensure indexable arrays for both scalar and multi-aperture cases
-        mean_bkg   = np.atleast_1d(mean_bkg)
+        mean_bkg = np.atleast_1d(mean_bkg)
         median_bkg = np.atleast_1d(median_bkg)
-        sigma_ann  = np.atleast_1d(sigma_ann)
+        sigma_ann = np.atleast_1d(sigma_ann)
 
         diff = np.abs(mean_bkg - median_bkg)
         bad = diff > tolerance * sigma_ann

--- a/src/photozpy/photometry/photometry.py
+++ b/src/photozpy/photometry/photometry.py
@@ -140,6 +140,11 @@ class Photometry():
         median_bkg = bkg_stats.median
         sigma_ann = bkg_stats.std
 
+        # Ensure indexable arrays for both scalar and multi-aperture cases
+        mean_bkg   = np.atleast_1d(mean_bkg)
+        median_bkg = np.atleast_1d(median_bkg)
+        sigma_ann  = np.atleast_1d(sigma_ann)
+
         diff = np.abs(mean_bkg - median_bkg)
         bad = diff > tolerance * sigma_ann
 


### PR DESCRIPTION
## Summary
This PR fixes an `IndexError: invalid index to scalar variable` that occurs when background statistics from `photutils.ApertureStats` are scalars (single annulus or single aperture position) but the warning formatter indexes them like arrays.

## Problem
`ApertureStats.mean`, `median`, and `std` can be returned as scalars when the `ApertureStats` instance is scalar (for example, a single aperture position). In that case, the warning block attempted to format values via `mean_bkg[i]`, which fails for scalar values and raises:
- `IndexError: invalid index to scalar variable`

`ApertureStats` provides an `isscalar` attribute indicating whether the instance is scalar.  
Separately, `numpy.atleast_1d` guarantees that scalar inputs become 1D arrays of length 1 while higher-dimensional inputs are preserved. 

## Solution
- Normalize `mean_bkg`, `median_bkg`, `sigma_ann`, and derived arrays (`diff`, `bad`) to 1D arrays using `np.atleast_1d(...)` before computing indices and formatting the warning message.
- This enables a single code path to handle both:
  - scalar `ApertureStats` outputs (single annulus)
  - vector outputs (multiple annuli or multiple apertures)

## Implementation details
- Convert background stats to indexable arrays:
  - `mean_bkg = np.atleast_1d(mean_bkg)` (and similarly for median and std)
- Compute `diff`, `bad`, and `bad_idx` using the normalized arrays.
- Format warning lines using the normalized arrays, ensuring `[...]` indexing is always valid.

## References
- `numpy.atleast_1d` converts scalar inputs to 1D arrays and preserves higher-dimensional inputs.  
- `photutils.ApertureStats.isscalar` indicates whether the stats object represents a single aperture position. 