### PR TITLE
Print Object Sky Coordinate in the Photometric Table

### DIFF
--- a/src/photozpy/sources/sources.py
+++ b/src/photozpy/sources/sources.py
@@ -239,7 +239,7 @@ class Sources():
 
         for target in self.targets:
             print(target.source_name)
-            print(target.skycoord.to_string("hmsdms", sep = ":", precision = 2, )[0])
+            print(target.skycoord.to_string("hmsdms", sep=":", precision=2, )[0])
             # print magnitudes
             print(f"The magnitudes in {telescope.filters} are:")
             for filter_names in telescope.filters:

--- a/src/photozpy/sources/sources.py
+++ b/src/photozpy/sources/sources.py
@@ -239,6 +239,7 @@ class Sources():
 
         for target in self.targets:
             print(target.source_name)
+            print(target.skycoord.to_string("hmsdms", sep = ":", precision = 2, )[0])
             # print magnitudes
             print(f"The magnitudes in {telescope.filters} are:")
             for filter_names in telescope.filters:


### PR DESCRIPTION
When printing the final calibrated photometric results, I print the object coordinates directly beneath the object name. This makes it easier to transfer the results into Google Sheets, since I need the coordinates to look up the Galactic extinction at the same time (e.g., via coordinate-based dust/extinction tools).
```
1RXS J091926.5-220052
09:19:26.23 -22:00:42.70
The magnitudes in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
21.1749
19.7321
19.6352
19.0002
The magnitude errors in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
nan
0.1154
0.1834
0.318
The detection significance in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
2.6672
9.4046
5.9213
3.414
======================================================================
======================================================================
PMN J1053-3743
10:52:58.10 -37:43:18.60
The magnitudes in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
18.0184
17.6975
17.3107
18.0199
The magnitude errors in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
0.0283
0.0253
0.0318
0.1925
The detection significance in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
38.3373
42.917
34.1784
5.6388
======================================================================
======================================================================
PKS 1205-778
12:08:18.36 -78:09:48.60
The magnitudes in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
20.7009
19.6928
19.0761
17.4617
The magnitude errors in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
nan
0.166
0.1707
0.121
The detection significance in ["SDSS_g'", "SDSS_r'", "SDSS_i'", "SDSS_z'"] are:
2.6826
6.5394
6.3616
8.9736
======================================================================
======================================================================
``` 