### PR TITLE
Add ImageCollectionGroup and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,36 @@ jobs:
           condarc: |
             channels:
               - conda-forge
-              - defaults
+            channel_priority: strict
 
       # Install your package in editable mode; keep deps managed by conda/mamba
       - name: Install photozpy (editable, no deps)
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e . --no-deps
+        shell: micromamba-shell {0}
+
+      # check version of some packages for debugging purpose
+      - name: Show installed scientific package versions
+        run: |
+          python - <<'PY'
+          import importlib.metadata as metadata
+          import numpy
+
+          print("NumPy runtime:", numpy.__version__)
+
+          for package in (
+              "numpy",
+              "astropy",
+              "astropy-healpix",
+              "ccdproc",
+              "photutils",
+          ):
+              try:
+                  print(f"{package}: {metadata.version(package)}")
+              except metadata.PackageNotFoundError:
+                  print(f"{package}: NOT INSTALLED")
+          PY
         shell: micromamba-shell {0}
 
       - name: Lint (ruff)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# Photozpy collaboration rules
+
+你是本项目的只读代码审阅者和编程教学助手。
+
+除非我明确要求，否则请使用中文回答；Python API、类名、函数名和代码注释可以保留英文。
+
+
+## 严格限制
+
+- 不得修改、创建、删除、移动或重命名任何文件。
+- 不得应用 patch。
+- 不得创建或切换 Git branch、worktree、commit、pull request 或 push。
+- 不得运行任何 shell command，除非我明确批准。
+- 我会亲自完成所有代码修改、测试运行和 Git 操作。
+
+## 读写规则
+
+- 允许执行纯只读的仓库检查命令，例如 pwd、ls、rg、grep、find、git status、git diff、git log、cat、sed -n、head、tail。
+- 不得执行任何会修改文件、Git 状态、环境、缓存、数据或网络状态的命令；对此类命令必须先请求我的明确批准。
+
+## 你的职责
+
+- 阅读并分析整个 repository。
+- 追踪 imports、call sites、tests、notebooks、CLI entry points 和 public APIs。
+- 在提出重构建议前，先说明相关模块职责、受影响文件、依赖关系和风险。
+- 识别 circular imports、backward compatibility 和 hidden coupling 风险。
+- 提供小范围、可手动复制粘贴的代码建议，并解释每一处修改的原因。
+- 多给小步骤而非大段重写。
+- 建议我应当手动运行哪些 tests、commands 或 science validation checks。
+- 使用清晰 Markdown：标题、列表、表格、代码块和分步骤解释。
+
+## Refactoring workflow
+
+在提出代码修改前，请依次说明：
+
+1. 当前代码结构和问题；
+2. 全 repo 的影响范围；
+3. API、import 和科学行为风险；
+4. 最小、可独立验证的重构步骤。
+
+在我确认某一步之前，不要给出大范围实现方案。
+
+## Scientific constraints
+
+Photozpy 是科研代码。除非我明确要求改变科学逻辑，否则必须保持现有科学行为不变。
+
+以下内容视为高风险逻辑，不能因为代码更简洁而改变：
+
+- photometric calibration；
+- magnitude、flux、AB/Vega conventions；
+- upper-limit definition、direction 和 plotting behavior；
+- uncertainty propagation；
+- extinction correction；
+- filter mapping；
+- aperture photometry；
+- source detection threshold；
+- non-detection handling；
+- output table columns、units、formats 和 backward compatibility。
+
+如果无法从代码中确认科学行为，请明确说明不确定之处，不要自行假设。

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: photozpy_dev
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.11
   - pip
@@ -19,7 +18,7 @@ dependencies:
   - astroquery>=0.4.7,<0.5
   - regions>=0.8,<1
   - astroalign>=2.5,<3
-  - astropy-healpix
+  - astropy-healpix>=1.0.3,<2
   - pytables
 
   # --- standard star metadata visualization ---

--- a/src/photozpy/collections/__init__.py
+++ b/src/photozpy/collections/__init__.py
@@ -1,0 +1,5 @@
+from .image_collection_group import ImageCollectionGroup
+
+__all__ = [
+    "ImageCollectionGroup",
+]

--- a/src/photozpy/collections/image_collection_group.py
+++ b/src/photozpy/collections/image_collection_group.py
@@ -1,0 +1,336 @@
+from pathlib import Path
+from collections.abc import Iterable
+
+from ccdproc import ImageFileCollection
+
+
+class ImageCollectionGroup:
+    """
+    A group of one or more `ccdproc.ImageFileCollection` objects.
+
+    This class provides a lightweight container for working with image
+    collections from multiple directories. Each child collection represents
+    one directory and remains an independent `ImageFileCollection`.
+
+    The group can be created either from directories that share the same
+    `ImageFileCollection` configuration, or from existing, independently
+    configured `ImageFileCollection` objects.
+
+    Parameters
+    ----------
+    directories : str, pathlib.Path, or iterable of str or pathlib.Path
+        One directory or an iterable of directories used to create child
+        `ImageFileCollection` objects. Relative paths and ``~`` are converted
+        to normalized absolute paths before child collections are created.
+
+    **image_file_collection_kwargs
+        Keyword arguments forwarded unchanged to each child
+        `ccdproc.ImageFileCollection`, except ``location`` and ``filenames``.
+
+        ``location`` is controlled by ``directories``. ``filenames`` is not
+        accepted because one shared filename list does not have an unambiguous
+        meaning across multiple directories.
+
+    Raises
+    ------
+    TypeError
+        If ``directories`` is neither a path-like object nor an iterable of
+        path-like objects.
+
+        Also raised if ``location`` or ``filenames`` is passed through
+        ``image_file_collection_kwargs``.
+
+    ValueError
+        If ``directories`` is empty.
+
+    Notes
+    -----
+    The group stores child collections in the same order as their corresponding
+    directories. Therefore, for every valid index ``i``:
+
+    ``self._directories[i]`` corresponds to ``self._collections[i]``.
+
+    The group does not merge child collections into one large
+    `ImageFileCollection`. Each child retains its own configuration, summary
+    table, filtering behavior, and refresh state.
+
+    See Also
+    --------
+    ccdproc.ImageFileCollection
+        The single-directory collection class used by each child collection.
+
+    ImageCollectionGroup.from_collections
+        Create a group from existing `ImageFileCollection` objects with
+        potentially different configurations.
+    """
+    
+    def __init__(
+        self,
+        directories: str | Path | Iterable[str | Path],
+        **image_file_collection_kwargs,
+    ) -> None:
+        """
+        Create child `ImageFileCollection` objects from one or more directories.
+
+        A separate `ImageFileCollection` is created for every input directory.
+        All child collections receive the same keyword arguments.
+
+        Parameters
+        ----------
+        directories : str, pathlib.Path, or iterable of str or pathlib.Path
+            One directory or an iterable of directories. Each directory is
+            normalized with ``Path(...).expanduser().resolve()`` before being
+            passed to `ImageFileCollection`.
+
+        **image_file_collection_kwargs
+            Keyword arguments forwarded to every child
+            `ccdproc.ImageFileCollection`.
+
+            ``location`` and ``filenames`` are reserved and cannot be passed.
+            ``location`` is determined by each item in ``directories``.
+            ``filenames`` is intentionally unsupported because different
+            directories may require different filename selections.
+
+        Raises
+        ------
+        TypeError
+            If ``directories`` is not a path-like object or an iterable of
+            path-like objects.
+
+            Also raised if ``location`` or ``filenames`` is included in
+            ``image_file_collection_kwargs``.
+
+        ValueError
+            If ``directories`` is empty.
+        """
+
+        # These keyword arguments cannot be forwarded to ImageFileCollection,
+        # because ImageCollectionGroup controls child collection locations.
+        forbidden = {"location", "filenames"}
+        invalid = forbidden & image_file_collection_kwargs.keys()
+        if invalid:
+            names = ", ".join(sorted(invalid))
+            raise TypeError(
+                f"{names} must not be passed to ImageCollectionGroup. "
+                "Use 'directories' to define child collection locations."
+            )
+
+        # check directories type
+        if isinstance(directories, (str, Path)):
+            directories = (directories,)
+        elif not isinstance(directories, Iterable):
+            raise TypeError(
+                "'directories' must be a str, pathlib.Path, "
+                "or an iterable of str/pathlib.Path objects."
+            )
+        
+        self._directories = tuple(
+            Path(directory).expanduser().resolve()
+            for directory in directories
+        )
+        
+        # Reject an empty directory iterable.
+        if not self._directories:
+            raise ValueError(
+                "'directories' must contain at least one directory."
+            )
+
+        # Create one child ImageFileCollection for each directory.
+        self._collections = tuple(
+            ImageFileCollection(
+                location=directory,
+                **image_file_collection_kwargs,
+            )
+            for directory in self._directories
+        )
+
+    @classmethod
+    def from_collections(
+        cls, 
+        collections: ImageFileCollection | Iterable[ImageFileCollection],
+    ) -> "ImageCollectionGroup":
+        """
+        Create an `ImageCollectionGroup` from existing image collections.
+
+        This constructor preserves the original `ImageFileCollection` objects
+        rather than reconstructing them from their locations. It is intended
+        for cases where child collections use different configurations, such
+        as different ``glob_include``, ``glob_exclude``, ``ext``, ``keywords``,
+        or filename-selection rules.
+
+        Parameters
+        ----------
+        collections : ccdproc.ImageFileCollection or iterable of ccdproc.ImageFileCollection
+            One existing `ImageFileCollection` or an iterable of existing
+            `ImageFileCollection` objects.
+
+            Every collection must have a non-``None`` ``location`` attribute.
+            This requirement ensures that the group can maintain a directory
+            entry corresponding to every child collection.
+
+        Returns
+        -------
+        ImageCollectionGroup
+            A group containing the original `ImageFileCollection` objects.
+
+            The returned group preserves object identity. For example, if
+            ``collection_a`` is passed as the first item, then
+            ``group[0] is collection_a`` is ``True``.
+
+        Raises
+        ------
+        TypeError
+            If ``collections`` is neither an `ImageFileCollection` nor an
+            iterable of `ImageFileCollection` objects.
+
+            Also raised if any iterable element is not an
+            `ImageFileCollection`.
+
+        ValueError
+            If ``collections`` is empty.
+
+            Also raised if any child collection has ``location is None``.
+
+        Notes
+        -----
+        This method bypasses the normal ``__init__`` construction path so that
+        existing child collections are retained exactly as provided.
+
+        In particular, this method does not recreate child collections and
+        does not attempt to infer or reproduce their original construction
+        keyword arguments.
+        """
+        
+        # initialize collections tuple
+        if isinstance(collections, ImageFileCollection):
+            collections = (collections,)
+        elif not isinstance(collections, Iterable):
+            raise TypeError(
+                "'collections' must be an ImageFileCollection or an "
+                "iterable of ImageFileCollection objects."
+            )
+        else:
+            collections = tuple(collections)
+
+        # make sure the input collection is not an empty list
+        if not collections:
+            raise ValueError(
+                "'collections' must contain at least one ImageFileCollection."
+            )
+
+        # First check element types.
+        if not all(
+            isinstance(collection, ImageFileCollection)
+            for collection in collections
+        ):
+            raise TypeError(
+                "All items in 'collections' must be ImageFileCollection objects."
+            )
+        
+        # Then check whether each valid collection has one location.
+        for collection in collections:
+            if collection.location is None:
+                raise ValueError(
+                    "Each ImageFileCollection passed to "
+                    "ImageCollectionGroup.from_collections() "
+                    "must have a non-None location."
+                )
+
+        directories = tuple(
+            Path(collection.location).expanduser().resolve()
+            for collection in collections
+        )
+
+        image_group_collection = cls.__new__(cls)
+        image_group_collection._collections = collections
+        image_group_collection._directories = directories
+
+        return image_group_collection
+
+    def __iter__(self):
+        """
+        Iterate over child `ImageFileCollection` objects.
+
+        Yields
+        ------
+        ccdproc.ImageFileCollection
+            Child collections in the same order as the input directories or
+            input collections.
+
+        Examples
+        --------
+        >>> for collection in group:
+        ...     print(collection.location)
+        """
+        return iter(self._collections)
+
+    def __len__(self):
+        """
+        Return the number of child image collections in the group.
+
+        Returns
+        -------
+        int
+            Number of stored `ImageFileCollection` objects.
+
+        Examples
+        --------
+        >>> len(group)
+        3
+        """
+        return len(self._collections)
+
+    def __getitem__(self, index):
+        """
+        Parameters
+        ----------
+        index : int or slice
+            Integer index or slice applied to the child collection tuple.
+        
+        Returns
+        -------
+        ccdproc.ImageFileCollection or ImageCollectionGroup
+            A single child collection for an integer index, or a new
+            `ImageCollectionGroup` for a non-empty slice.
+        
+        Raises
+        ------
+        ValueError
+            If a slice selects no child collections. Empty groups are not valid
+            `ImageCollectionGroup` instances.
+        """
+        result = self._collections[index]
+    
+        if isinstance(index, slice):
+            return type(self).from_collections(result)
+    
+        return result
+
+    def items(self):
+        """
+        Iterate over directory and child-collection pairs.
+
+        Returns
+        -------
+        zip
+            An iterator yielding ``(directory, collection)`` pairs, where
+            ``directory`` is a normalized `pathlib.Path` and ``collection`` is
+            the corresponding `ccdproc.ImageFileCollection`.
+
+        Notes
+        -----
+        The returned object is a one-pass iterator. Convert it to a tuple or
+        list if the pairs need to be reused:
+
+        >>> pairs = tuple(group.items())
+
+        Repeated directories are allowed. Therefore, the directory value should
+        be treated as location metadata rather than a unique identifier for a
+        child collection.
+
+        Examples
+        --------
+        >>> for directory, collection in group.items():
+        ...     print(directory, collection.location)
+        """
+        return zip(self._directories, self._collections)

--- a/src/photozpy/collections/image_collection_group.py
+++ b/src/photozpy/collections/image_collection_group.py
@@ -164,7 +164,7 @@ class ImageCollectionGroup:
             One existing `ImageFileCollection` or an iterable of existing
             `ImageFileCollection` objects.
 
-            Every collection must have a non-``None`` ``location`` attribute.
+            Every collection must have a non-empty ``location`` attribute.
             This requirement ensures that the group can maintain a directory
             entry corresponding to every child collection.
 
@@ -189,7 +189,7 @@ class ImageCollectionGroup:
         ValueError
             If ``collections`` is empty.
 
-            Also raised if any child collection has ``location is None``.
+            Also raised if any child collection has an empty ``location``.
 
         Notes
         -----
@@ -229,11 +229,11 @@ class ImageCollectionGroup:
 
         # Then check whether each valid collection has one location.
         for collection in collections:
-            if collection.location is None:
+            if not collection.location:
                 raise ValueError(
                     "Each ImageFileCollection passed to "
                     "ImageCollectionGroup.from_collections() "
-                    "must have a non-None location."
+                    "must have a non-empty location."
                 )
 
         directories = tuple(

--- a/src/photozpy/collections/image_collection_group.py
+++ b/src/photozpy/collections/image_collection_group.py
@@ -63,7 +63,7 @@ class ImageCollectionGroup:
         Create a group from existing `ImageFileCollection` objects with
         potentially different configurations.
     """
-    
+
     def __init__(
         self,
         directories: str | Path | Iterable[str | Path],
@@ -123,12 +123,12 @@ class ImageCollectionGroup:
                 "'directories' must be a str, pathlib.Path, "
                 "or an iterable of str/pathlib.Path objects."
             )
-        
+
         self._directories = tuple(
             Path(directory).expanduser().resolve()
             for directory in directories
         )
-        
+
         # Reject an empty directory iterable.
         if not self._directories:
             raise ValueError(
@@ -146,7 +146,7 @@ class ImageCollectionGroup:
 
     @classmethod
     def from_collections(
-        cls, 
+        cls,
         collections: ImageFileCollection | Iterable[ImageFileCollection],
     ) -> "ImageCollectionGroup":
         """
@@ -200,7 +200,7 @@ class ImageCollectionGroup:
         does not attempt to infer or reproduce their original construction
         keyword arguments.
         """
-        
+
         # initialize collections tuple
         if isinstance(collections, ImageFileCollection):
             collections = (collections,)
@@ -226,7 +226,7 @@ class ImageCollectionGroup:
             raise TypeError(
                 "All items in 'collections' must be ImageFileCollection objects."
             )
-        
+
         # Then check whether each valid collection has one location.
         for collection in collections:
             if collection.location is None:
@@ -286,13 +286,13 @@ class ImageCollectionGroup:
         ----------
         index : int or slice
             Integer index or slice applied to the child collection tuple.
-        
+
         Returns
         -------
         ccdproc.ImageFileCollection or ImageCollectionGroup
             A single child collection for an integer index, or a new
             `ImageCollectionGroup` for a non-empty slice.
-        
+
         Raises
         ------
         ValueError
@@ -300,10 +300,10 @@ class ImageCollectionGroup:
             `ImageCollectionGroup` instances.
         """
         result = self._collections[index]
-    
+
         if isinstance(index, slice):
             return type(self).from_collections(result)
-    
+
         return result
 
     def items(self):

--- a/tests/test_image_collection_group.py
+++ b/tests/test_image_collection_group.py
@@ -1,0 +1,425 @@
+from pathlib import Path
+
+import pytest
+from astropy.io import fits
+from ccdproc import ImageFileCollection
+
+from photozpy.collections import ImageCollectionGroup
+
+
+def write_minimal_fits(path: Path) -> None:
+    """Write one minimal valid FITS file."""
+    fits.PrimaryHDU().writeto(path)
+
+
+@pytest.fixture
+def image_directories(tmp_path: Path) -> tuple[Path, Path]:
+    """Create two directories containing minimal FITS files."""
+    directory_a = tmp_path / "source_a"
+    directory_b = tmp_path / "source_b"
+
+    directory_a.mkdir()
+    directory_b.mkdir()
+
+    write_minimal_fits(directory_a / "a.fits")
+    write_minimal_fits(directory_b / "b.fits")
+
+    return directory_a, directory_b
+
+
+@pytest.fixture
+def image_collections(
+    image_directories: tuple[Path, Path],
+) -> tuple[ImageFileCollection, ImageFileCollection]:
+    """Create two independently configured ImageFileCollection objects."""
+    directory_a, directory_b = image_directories
+
+    collection_a = ImageFileCollection(
+        location=directory_a,
+        glob_include="a.fits",
+    )
+
+    collection_b = ImageFileCollection(
+        location=directory_b,
+        glob_include="b.fits",
+    )
+
+    return collection_a, collection_b
+
+
+def test_init_creates_one_collection_for_single_path(
+    image_directories: tuple[Path, Path],
+) -> None:
+    directory_a, _ = image_directories
+
+    group = ImageCollectionGroup(directory_a)
+
+    assert len(group) == 1
+    assert isinstance(group[0], ImageFileCollection)
+    assert Path(group[0].location).resolve() == directory_a.resolve()
+
+
+def test_init_creates_one_collection_for_single_string_path(
+    image_directories: tuple[Path, Path],
+) -> None:
+    directory_a, _ = image_directories
+
+    group = ImageCollectionGroup(str(directory_a))
+
+    assert len(group) == 1
+    assert Path(group[0].location).resolve() == directory_a.resolve()
+
+
+def test_init_creates_collections_in_directory_order(
+    image_directories: tuple[Path, Path],
+) -> None:
+    directory_a, directory_b = image_directories
+
+    group = ImageCollectionGroup(
+        [directory_a, directory_b],
+    )
+
+    assert len(group) == 2
+    assert Path(group[0].location).resolve() == directory_a.resolve()
+    assert Path(group[1].location).resolve() == directory_b.resolve()
+
+
+def test_init_accepts_generator_of_directories(
+    image_directories: tuple[Path, Path],
+) -> None:
+    directory_a, directory_b = image_directories
+
+    directories = (
+        directory
+        for directory in (directory_a, directory_b)
+    )
+
+    group = ImageCollectionGroup(directories)
+
+    assert len(group) == 2
+    assert group._directories == (
+        directory_a.resolve(),
+        directory_b.resolve(),
+    )
+
+
+def test_init_forwards_image_file_collection_kwargs(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "source"
+    directory.mkdir()
+
+    write_minimal_fits(directory / "raw.fits")
+    write_minimal_fits(directory / "reduced.fits")
+
+    group = ImageCollectionGroup(
+        directory,
+        glob_include="raw.fits",
+    )
+
+    assert group[0].files == ["raw.fits"]
+
+
+def test_init_rejects_non_iterable_directories() -> None:
+    with pytest.raises(
+        TypeError,
+        match="must be a str, pathlib.Path, or an iterable",
+    ):
+        ImageCollectionGroup(42)
+
+
+@pytest.mark.parametrize(
+    "directories",
+    [
+        [],
+        (),
+        (directory for directory in ()),
+    ],
+)
+def test_init_rejects_empty_directory_iterable(
+    directories,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="must contain at least one directory",
+    ):
+        ImageCollectionGroup(directories)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"location": "other_directory"},
+        {"filenames": ["a.fits"]},
+    ],
+)
+def test_init_rejects_reserved_image_file_collection_kwargs(
+    image_directories: tuple[Path, Path],
+    kwargs: dict,
+) -> None:
+    directory_a, _ = image_directories
+
+    with pytest.raises(
+        TypeError,
+        match="must not be passed to ImageCollectionGroup",
+    ):
+        ImageCollectionGroup(
+            directory_a,
+            **kwargs,
+        )
+
+
+def test_iter_returns_child_collections_in_order(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    group = ImageCollectionGroup.from_collections(
+        [collection_a, collection_b],
+    )
+
+    assert tuple(group) == (
+        collection_a,
+        collection_b,
+    )
+
+
+def test_len_returns_number_of_child_collections(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    group = ImageCollectionGroup.from_collections(
+        image_collections,
+    )
+
+    assert len(group) == 2
+
+
+def test_from_collections_accepts_single_collection(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, _ = image_collections
+
+    group = ImageCollectionGroup.from_collections(collection_a)
+
+    assert len(group) == 1
+    assert group[0] is collection_a
+
+
+def test_from_collections_preserves_child_identity(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    group = ImageCollectionGroup.from_collections(
+        [collection_a, collection_b],
+    )
+
+    assert group[0] is collection_a
+    assert group[1] is collection_b
+
+
+def test_from_collections_accepts_generator_of_collections(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    collections = (
+        collection
+        for collection in (collection_a, collection_b)
+    )
+
+    group = ImageCollectionGroup.from_collections(collections)
+
+    assert len(group) == 2
+    assert group[0] is collection_a
+    assert group[1] is collection_b
+
+
+def test_from_collections_allows_same_location_with_different_configs(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "source"
+    directory.mkdir()
+
+    write_minimal_fits(directory / "raw.fits")
+    write_minimal_fits(directory / "reduced.fits")
+
+    raw_collection = ImageFileCollection(
+        location=directory,
+        glob_include="raw.fits",
+    )
+
+    reduced_collection = ImageFileCollection(
+        location=directory,
+        glob_include="reduced.fits",
+    )
+
+    group = ImageCollectionGroup.from_collections(
+        [raw_collection, reduced_collection],
+    )
+
+    assert len(group) == 2
+    assert group[0] is raw_collection
+    assert group[1] is reduced_collection
+
+    assert tuple(
+        directory_
+        for directory_, _ in group.items()
+    ) == (
+        directory.resolve(),
+        directory.resolve(),
+    )
+
+
+@pytest.mark.parametrize(
+    "collections",
+    [
+        [],
+        (),
+        (collection for collection in ()),
+    ],
+)
+def test_from_collections_rejects_empty_iterable(
+    collections,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="must contain at least one ImageFileCollection",
+    ):
+        ImageCollectionGroup.from_collections(collections)
+
+
+@pytest.mark.parametrize(
+    "collections",
+    [
+        [None],
+        ["not an image collection"],
+        [ImageFileCollection, None],
+    ],
+)
+def test_from_collections_rejects_non_collection_elements(
+    collections,
+) -> None:
+    with pytest.raises(
+        TypeError,
+        match="All items in 'collections' must be ImageFileCollection",
+    ):
+        ImageCollectionGroup.from_collections(collections)
+
+
+def test_getitem_returns_collection_for_integer_index(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    group = ImageCollectionGroup.from_collections(
+        [collection_a, collection_b],
+    )
+
+    assert group[0] is collection_a
+    assert group[1] is collection_b
+
+
+def test_getitem_returns_collection_for_negative_index(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    group = ImageCollectionGroup.from_collections(
+        [collection_a, collection_b],
+    )
+
+    assert group[-1] is collection_b
+    assert group[-2] is collection_a
+
+
+def test_getitem_returns_group_for_nonempty_slice(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    group = ImageCollectionGroup.from_collections(
+        [collection_a, collection_b],
+    )
+
+    subgroup = group[1:2]
+
+    assert isinstance(subgroup, ImageCollectionGroup)
+    assert len(subgroup) == 1
+    assert subgroup[0] is collection_b
+    assert subgroup[0] is not collection_a
+
+
+def test_getitem_reverse_slice_preserves_child_identity(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    group = ImageCollectionGroup.from_collections(
+        [collection_a, collection_b],
+    )
+
+    reverse_group = group[::-1]
+
+    assert isinstance(reverse_group, ImageCollectionGroup)
+    assert reverse_group[0] is collection_b
+    assert reverse_group[1] is collection_a
+
+
+def test_getitem_raises_value_error_for_empty_slice(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    group = ImageCollectionGroup.from_collections(
+        image_collections,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="must contain at least one ImageFileCollection",
+    ):
+        group[0:0]
+
+
+def test_items_returns_directory_collection_pairs_in_order(
+    image_collections: tuple[ImageFileCollection, ImageFileCollection],
+) -> None:
+    collection_a, collection_b = image_collections
+
+    group = ImageCollectionGroup.from_collections(
+        [collection_a, collection_b],
+    )
+
+    items = tuple(group.items())
+
+    assert items[0][0] == Path(collection_a.location).resolve()
+    assert items[1][0] == Path(collection_b.location).resolve()
+
+    assert items[0][1] is collection_a
+    assert items[1][1] is collection_b
+
+
+def test_from_collections_rejects_collection_without_location(
+    tmp_path: Path,
+) -> None:
+    fits_path = tmp_path / "image.fits"
+    write_minimal_fits(fits_path)
+
+    collection = ImageFileCollection(
+        filenames=[fits_path],
+    )
+
+    assert not collection.location
+
+    with pytest.raises(
+        ValueError,
+        match="must have a non-empty location",
+    ):
+        ImageCollectionGroup.from_collections(collection)
+
+
+def test_from_collections_rejects_non_iterable_input() -> None:
+    with pytest.raises(
+        TypeError,
+        match="must be an ImageFileCollection or an iterable",
+    ):
+        ImageCollectionGroup.from_collections(42)


### PR DESCRIPTION
## Summary

This PR introduces the first implementation of `ImageCollectionGroup`, a lightweight composition-based container for working with multiple `ccdproc.ImageFileCollection` objects.

The new class supports two construction paths:

- Creating one child `ImageFileCollection` per input directory, using shared configuration.
- Creating a group from existing `ImageFileCollection` objects while preserving their original configuration and object identity.

The implementation keeps directory and collection ordering aligned, supports iteration, indexing, slicing, and `(directory, collection)` pair iteration through `items()`.

## Key behavior

- Accepts a single directory, an iterable of directories, or existing `ImageFileCollection` objects.
- Normalizes stored directory paths with `Path(...).expanduser().resolve()`.
- Rejects empty groups.
- Rejects ambiguous `location` and `filenames` keyword arguments when constructing from directories.
- Preserves child collection identity in `from_collections()` and sliced groups.
- Rejects child collections without a non-empty `location`.
- Allows multiple child collections to reference the same directory when they use different configurations.

## Tests

Added unit tests for `ImageCollectionGroup` covering:

- Single-path, string-path, iterable, and generator directory inputs.
- Forwarding supported `ImageFileCollection` keyword arguments.
- Empty, invalid, and non-iterable inputs.
- Reserved `location` and `filenames` keyword arguments.
- `from_collections()` identity preservation and generator inputs.
- Collections sharing the same location but using different configurations.
- Integer indexing, negative indexing, non-empty slicing, reverse slicing, and empty-slice behavior.
- Iteration, `len()`, and `items()` ordering.
- Collections without a valid location.

The new module currently reaches 100% line and branch coverage in its dedicated test suite.

## Follow-up work

This PR also adds an empty `image_collection_helpers.py` module as a placeholder for the next refactoring step.

The intended follow-up is to move reusable single-collection helper behavior out of the legacy `mImageFileCollection` implementation and into focused helper functions, while keeping `ImageCollectionGroup` limited to multi-directory grouping behavior.

## CI environment

This PR also constrains `astropy-healpix` to the NumPy 1-compatible
release line and uses strict conda-forge channel priority in CI.

This prevents a NumPy C-API mismatch between the runtime NumPy version
(`numpy<2`) and binary extension packages.